### PR TITLE
Align more closely to Backbone API

### DIFF
--- a/backbone-pegasus.js
+++ b/backbone-pegasus.js
@@ -47,30 +47,31 @@
             model[method](data);
 
             if (options && options.success) {
-              options.success(model, data, options);
+              options.success(data);
             }
 
             model.trigger('sync', model, data, options);
           },
           // Error
-          function(data) {
+          function(data, xhr) {
             if (options && options.error) {
-              options.error(model, data, options);
+              options.error(xhr);
             }
 
-            model.trigger('error', model, data, options);
+            model.trigger('error', model, xhr, options);
           }
         );
+        return request;
 
       } else {
         // No request found for URL, use the original sync method
-        BackboneSync(method, model, options);
+        return BackboneSync(method, model, options);
       }
 
     } else {
 
       // Not a GET or no URL, use the original sync method
-      BackboneSync(method, model, options);
+      return BackboneSync(method, model, options);
 
     }
   }


### PR DESCRIPTION
A bit counterintuitive, but without these changes the Pegasus'ed Backbone.sync lacks its documented return value, and the arguments of options.success and options.error and the according events differ from the un-pegasus'ed variants. IMHO the Backbone documentation is a bit misleading about this, but just compare the arguments with and without Pegasus to verify that this works. This PR relates to #1, actually we're colleagues.
